### PR TITLE
Fix release pipeline git auto-commit action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
+    # Required for stefanzweifel/git-auto-commit-action to push badge updates
+    permissions:
+      contents: write
+
     strategy:
       matrix:
         node-version: [20.x, 22.x]


### PR DESCRIPTION
The badge update step uses stefanzweifel/git-auto-commit-action which requires explicit contents:write permission on the GITHUB_TOKEN to push commits back to the repository. Without this, the action receives a 403 permission denied error from GitHub.

This is distinct from the previous CRLF fix - that addressed hook execution failures during commit phase, while this addresses the GitHub-level permission needed for the push phase.

Reference: https://github.com/stefanzweifel/git-auto-commit-action#usage