### PR TITLE
Debug runner activity issues

### DIFF
--- a/src/seed/summary.test.ts
+++ b/src/seed/summary.test.ts
@@ -161,5 +161,86 @@ describe('summary', () => {
             expect(md).toContain('PR #5');
             expect(md).toContain('Network error');
         });
+
+        describe('cleanup mode', () => {
+            it('shows cleanup mode header and statistics when cleanupMode is true', () => {
+                const cleanupSummary: SeedSummary = {
+                    ...baseSummary,
+                    repos: [], // Empty in cleanup mode
+                    cleanupMode: true,
+                    cleanupStats: {
+                        draftsPublished: 5,
+                        prsCompleted: 213,
+                        prsFailed: 2,
+                    },
+                };
+
+                const md = generateMarkdownSummary(cleanupSummary);
+
+                expect(md).toContain('Cleanup Mode');
+                expect(md).toContain('PRs Completed:** 213');
+                expect(md).toContain('Drafts Published:** 5');
+                expect(md).toContain('PRs Failed:** 2');
+            });
+
+            it('does not show normal statistics in cleanup mode', () => {
+                const cleanupSummary: SeedSummary = {
+                    ...baseSummary,
+                    repos: [],
+                    cleanupMode: true,
+                    cleanupStats: {
+                        draftsPublished: 0,
+                        prsCompleted: 50,
+                        prsFailed: 0,
+                    },
+                };
+
+                const md = generateMarkdownSummary(cleanupSummary);
+
+                // Should NOT contain normal seeding stats
+                expect(md).not.toContain('Repositories:**');
+                expect(md).not.toContain('Branches Created:**');
+                expect(md).not.toContain('Non-Fatal Failures:**');
+            });
+
+            it('includes cleanup explanation text', () => {
+                const cleanupSummary: SeedSummary = {
+                    ...baseSummary,
+                    cleanupMode: true,
+                    cleanupStats: {
+                        draftsPublished: 0,
+                        prsCompleted: 10,
+                        prsFailed: 0,
+                    },
+                };
+
+                const md = generateMarkdownSummary(cleanupSummary);
+
+                expect(md).toContain('threshold');
+                expect(md).toContain('prioritized');
+            });
+
+            it('still shows fatal failure in cleanup mode', () => {
+                const cleanupWithFatal: SeedSummary = {
+                    ...baseSummary,
+                    cleanupMode: true,
+                    cleanupStats: {
+                        draftsPublished: 0,
+                        prsCompleted: 0,
+                        prsFailed: 0,
+                    },
+                    fatalFailure: {
+                        phase: 'identity-resolution',
+                        error: 'Failed to resolve user',
+                    },
+                };
+
+                const md = generateMarkdownSummary(cleanupWithFatal);
+
+                expect(md).toContain('Fatal Failure');
+                expect(md).toContain('identity-resolution');
+                expect(md).toContain('Failed to resolve user');
+            });
+        });
     });
 });

--- a/src/seed/summary.ts
+++ b/src/seed/summary.ts
@@ -74,7 +74,21 @@ export function generateMarkdownSummary(summary: SeedSummary): string {
         lines.push('');
     }
 
-    // Statistics
+    // Handle cleanup mode differently - show cleanup statistics prominently
+    if (summary.cleanupMode && summary.cleanupStats) {
+        lines.push(`## 🧹 Cleanup Mode`);
+        lines.push('');
+        lines.push('Open PR count exceeded threshold. Cleanup mode prioritized completing existing PRs.');
+        lines.push('');
+        lines.push(`## Statistics`);
+        lines.push(`- **PRs Completed:** ${summary.cleanupStats.prsCompleted}`);
+        lines.push(`- **Drafts Published:** ${summary.cleanupStats.draftsPublished}`);
+        lines.push(`- **PRs Failed:** ${summary.cleanupStats.prsFailed}`);
+        lines.push('');
+        return lines.join('\n');
+    }
+
+    // Normal seeding mode statistics
     const totalRepos = summary.repos.length;
     const totalPrs = summary.repos.reduce((sum, r) => sum + r.prs.length, 0);
     const totalBranches = summary.repos.reduce((sum, r) => sum + r.branchesCreated, 0);


### PR DESCRIPTION
BUG: The generateMarkdownSummary() function only calculated statistics from summary.repos[], which is empty during cleanup mode. This caused the summary to show 0 repos, 0 branches, 0 PRs even when cleanup mode successfully completed hundreds of PRs.

The JSON output correctly showed cleanupStats.prsCompleted: 213, but the markdown summary ignored this data entirely, making it appear that no activity occurred.

Fix: When cleanupMode is true and cleanupStats exists, display cleanup- specific statistics (PRs Completed, Drafts Published, PRs Failed) with a clear header indicating cleanup mode was triggered.

Adds 4 tests for cleanup mode markdown summary:
- Shows cleanup mode header and statistics
- Does not show normal statistics in cleanup mode
- Includes cleanup explanation text
- Still shows fatal failures in cleanup mode