### PR TITLE
Improve seeder realism: variable cadence + seeded commit author attribution

### DIFF
--- a/.github/workflows/simulate-activity.yml
+++ b/.github/workflows/simulate-activity.yml
@@ -2,9 +2,12 @@ name: Simulate Activity
 
 on:
   schedule:
-    # Runs at 10:00 and 18:00 UTC daily
+    # Weekday cadence (higher activity)
+    - cron: '15 9 * * 1-5'
+    - cron: '45 14 * * 1-5'
+    - cron: '30 20 * * 1-5'
+    # Weekend cadence (lower activity)
     - cron: '0 10 * * *'
-    - cron: '0 18 * * *'
   workflow_dispatch: # Allow manual trigger
 
 concurrency:
@@ -32,12 +35,25 @@ jobs:
       - name: Generate Run ID and Date
         id: runid
         run: |
-          RUN_ID="auto-$(date -u +'%Y%m%d-%H%M')"
+          DOW="$(date -u +'%u')"
+          HOUR="$(date -u +'%H')"
+          RND="$((RANDOM % 100))"
+          # On weekends, skip 60% of scheduled runs to reduce robotic uniformity.
+          if [ "$DOW" -ge 6 ] && [ "$RND" -lt 60 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "run_id=skip-$(date -u +'%Y%m%d-%H%M')" >> $GITHUB_OUTPUT
+            echo "target_date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          RUN_ID="auto-$(date -u +'%Y%m%d')-h${HOUR}-r${RND}"
           TARGET_DATE="$(date -u +'%Y-%m-%d')"
+          echo "skip=false" >> $GITHUB_OUTPUT
           echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "target_date=$TARGET_DATE" >> $GITHUB_OUTPUT
 
       - name: Run Seeder
+        if: steps.runid.outputs.skip != 'true'
         env:
           ADO_PAT_DEV1: ${{ secrets.ADO_PAT_DEV1 }}
           ADO_PAT_DEV2: ${{ secrets.ADO_PAT_DEV2 }}
@@ -46,6 +62,10 @@ jobs:
           node dist/cli.js \
             --run-id ${{ steps.runid.outputs.run_id }} \
             --date ${{ steps.runid.outputs.target_date }}
+
+      - name: Note skipped run
+        if: steps.runid.outputs.skip == 'true'
+        run: echo "Weekend run intentionally skipped to preserve realistic activity variance."
 
       - name: Upload Summary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/simulate-activity.yml
+++ b/.github/workflows/simulate-activity.yml
@@ -7,7 +7,7 @@ on:
     - cron: '45 14 * * 1-5'
     - cron: '30 20 * * 1-5'
     # Weekend cadence (lower activity)
-    - cron: '0 10 * * *'
+    - cron: '0 10 * * 0,6'
   workflow_dispatch: # Allow manual trigger
 
 concurrency:
@@ -38,8 +38,8 @@ jobs:
           DOW="$(date -u +'%u')"
           HOUR="$(date -u +'%H')"
           RND="$((RANDOM % 100))"
-          # On weekends, skip 60% of scheduled runs to reduce robotic uniformity.
-          if [ "$DOW" -ge 6 ] && [ "$RND" -lt 60 ]; then
+          # On scheduled weekend runs, skip 60% to reduce robotic uniformity.
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "$DOW" -ge 6 ] && [ "$RND" -lt 60 ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
             echo "run_id=skip-$(date -u +'%Y%m%d-%H%M')" >> $GITHUB_OUTPUT
             echo "target_date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -65,7 +65,7 @@ jobs:
 
       - name: Note skipped run
         if: steps.runid.outputs.skip == 'true'
-        run: echo "Weekend run intentionally skipped to preserve realistic activity variance."
+        run: echo "Scheduled weekend run intentionally skipped to preserve realistic activity variance."
 
       - name: Upload Summary
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ADO Git Repo Seeder (v1.1.0)
 
 <!-- BADGES:START -->
-[![CI](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml/badge.svg)](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/badge/coverage-82%25-brightgreen)](./coverage/index.html) [![Version](https://img.shields.io/badge/version-1.1.0-blue)](./package.json) [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-green)](./package.json)
+[![CI](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml/badge.svg)](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/badge/coverage-81%25-brightgreen)](./coverage/index.html) [![Version](https://img.shields.io/badge/version-1.1.0-blue)](./package.json) [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-green)](./package.json)
 <!-- BADGES:END -->
 
 A professional, configurable Node.js tool to seed realistic, multi-user Pull Request activity in Azure DevOps.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ADO Git Repo Seeder (v1.1.0)
 
 <!-- BADGES:START -->
-[![CI](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml/badge.svg)](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/badge/coverage-81%25-brightgreen)](./coverage/index.html) [![Version](https://img.shields.io/badge/version-1.1.0-blue)](./package.json) [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-green)](./package.json)
+[![CI](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml/badge.svg)](https://github.com/oddessentials/ado-git-repo-seeder/actions/workflows/ci.yml) [![Coverage](https://img.shields.io/badge/coverage-82%25-brightgreen)](./coverage/index.html) [![Version](https://img.shields.io/badge/version-1.1.0-blue)](./package.json) [![Node](https://img.shields.io/badge/node-%3E%3D20.0.0-green)](./package.json)
 <!-- BADGES:END -->
 
 A professional, configurable Node.js tool to seed realistic, multi-user Pull Request activity in Azure DevOps.

--- a/src/git/generator.test.ts
+++ b/src/git/generator.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, Mock } from 'vitest';
+import { GitGenerator } from './generator.js';
+import { SeededRng } from '../util/rng.js';
+import { exec } from '../util/exec.js';
+
+vi.mock('../util/exec.js');
+
+describe('GitGenerator commit author attribution', () => {
+    it('adds --author with configured user emails for generated commits', async () => {
+        vi.clearAllMocks();
+        (exec as Mock).mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+
+        const generator = new GitGenerator(new SeededRng(42), undefined, [], undefined, [
+            'dev1@example.com',
+            'dev.two@example.com',
+        ]);
+
+        const generated = await generator.createRepo(
+            'author-test-repo',
+            [{ name: 'feature/test-run-0', commits: 1 }],
+            42,
+            'test-run'
+        );
+
+        const commitCalls = (exec as Mock).mock.calls.filter(
+            (call) => call[0] === 'git' && Array.isArray(call[1]) && call[1][0] === 'commit'
+        );
+
+        expect(commitCalls.length).toBeGreaterThan(0);
+        for (const call of commitCalls) {
+            const args: string[] = call[1];
+            expect(args).toContain('--author');
+            const authorIdx = args.indexOf('--author');
+            expect(args[authorIdx + 1]).toMatch(/<.+@example\.com>$/);
+        }
+
+        generated.cleanup();
+    });
+
+    it('omits --author when no commit authors are configured', async () => {
+        vi.clearAllMocks();
+        (exec as Mock).mockResolvedValue({ stdout: '', stderr: '', code: 0 });
+
+        const generator = new GitGenerator(new SeededRng(99));
+
+        await generator.createRepo('no-author-repo', [{ name: 'feature/no-author', commits: 1 }], 99, 'run-1');
+
+        const commitCalls = (exec as Mock).mock.calls.filter(
+            (call) => call[0] === 'git' && Array.isArray(call[1]) && call[1][0] === 'commit'
+        );
+
+        expect(commitCalls.length).toBeGreaterThan(0);
+        for (const call of commitCalls) {
+            const args: string[] = call[1];
+            expect(args).not.toContain('--author');
+        }
+    });
+});

--- a/src/git/generator.ts
+++ b/src/git/generator.ts
@@ -24,12 +24,20 @@ export class GitGenerator {
     private rng: SeededRng;
     private patsToRedact: string[];
     private targetDate?: string; // ISO timestamp for backdating commits
+    private commitAuthors: string[];
 
-    constructor(rng: SeededRng, fixturesPath?: string, patsToRedact: string[] = [], targetDate?: string) {
+    constructor(
+        rng: SeededRng,
+        fixturesPath?: string,
+        patsToRedact: string[] = [],
+        targetDate?: string,
+        commitAuthors: string[] = []
+    ) {
         this.rng = rng;
         this.deriver = new ContentDeriver(rng, fixturesPath);
         this.patsToRedact = patsToRedact;
         this.targetDate = targetDate;
+        this.commitAuthors = commitAuthors;
     }
 
     /**
@@ -67,7 +75,7 @@ export class GitGenerator {
             // Create initial commit on main
             writeFileSync(join(actualTempDir, 'README.md'), `# ${repoName}\n\nSeeded repository.`);
             await this.git(actualTempDir, ['add', '.']);
-            await this.git(actualTempDir, ['commit', '-m', 'Initial commit']);
+            await this.git(actualTempDir, this.createCommitArgs('Initial commit', this.rng));
             await this.git(actualTempDir, ['branch', '-M', 'main']);
 
             // Create branches
@@ -94,7 +102,7 @@ export class GitGenerator {
                         writeFileSync(filePath, file.content);
                     }
                     await this.git(actualTempDir, ['add', '.']);
-                    await this.git(actualTempDir, ['commit', '-m', `${branch.name}: commit ${i + 1}`]);
+                    await this.git(actualTempDir, this.createCommitArgs(`${branch.name}: commit ${i + 1}`, commitRng));
                 }
 
                 createdBranches.push(branch.name);
@@ -193,7 +201,7 @@ export class GitGenerator {
                 writeFileSync(filePath, file.content);
             }
             await this.git(localPath, ['add', '.']);
-            await this.git(localPath, ['commit', '-m', `Follow-up: addressing feedback ${i + 1}`]);
+            await this.git(localPath, this.createCommitArgs(`Follow-up: addressing feedback ${i + 1}`, commitRng));
         }
 
         const url = new URL(remoteUrl);
@@ -210,6 +218,33 @@ export class GitGenerator {
             askPass.cleanup();
         }
         return { count: commitCount };
+    }
+
+    private createCommitArgs(message: string, rng: SeededRng): string[] {
+        const args = ['commit', '-m', message];
+        const author = this.pickCommitAuthor(rng);
+        if (author) {
+            args.push('--author', author);
+        }
+        return args;
+    }
+
+    private pickCommitAuthor(rng: SeededRng): string | null {
+        if (this.commitAuthors.length === 0) {
+            return null;
+        }
+        const email = rng.pick(this.commitAuthors);
+        const namePart = email
+            .split('@')[0]
+            .replace(/[._-]+/g, ' ')
+            .trim();
+        const displayName = namePart
+            .split(/\s+/)
+            .filter((token) => token.length > 0)
+            .map((token) => token[0].toUpperCase() + token.slice(1))
+            .join(' ');
+        const fallbackName = 'Seeder User';
+        return `${displayName || fallbackName} <${email}>`;
     }
 
     /**

--- a/src/seed/runner.ts
+++ b/src/seed/runner.ts
@@ -68,7 +68,13 @@ export class SeedRunner {
         this.identityResolver = new IdentityResolver(this.identityClient, config.org);
         this.repoManager = new RepoManager(this.adoClient);
         this.prManager = new PrManager(this.adoClient);
-        this.gitGenerator = new GitGenerator(new SeededRng(config.seed), fixturesPath, this.allPats, targetDate);
+        this.gitGenerator = new GitGenerator(
+            new SeededRng(config.seed),
+            fixturesPath,
+            this.allPats,
+            targetDate,
+            config.resolvedUsers.map((user) => user.email)
+        );
 
         // Create per-user clients
         for (const user of config.resolvedUsers) {


### PR DESCRIPTION
### Motivation
- The simulated activity looked too uniform (rigid schedule and single committing identity), reducing the realism of contribution graphs and throughput heatmaps.  
- The change aims to keep deterministic behavior while producing more human-like variance in run frequency and commit authorship.  

### Description
- Change the GitHub Actions schedule to a weekday-heavy cadence with three distinct slots and a probabilistic weekend skip path, and produce run IDs that include hour + random bucket for less rigid traces (file: `.github/workflows/simulate-activity.yml`).  
- Rotate commit authors by wiring configured user emails into `GitGenerator` and adding deterministic `--author` on generated commits via `createCommitArgs` / `pickCommitAuthor` (file: `src/git/generator.ts`).  
- Wire resolved user emails from `SeedRunner` into `GitGenerator` so commit-author pools reflect the configured users (file: `src/seed/runner.ts`).  
- Add unit tests validating commit-author behavior when an author pool is present vs absent (file: `src/git/generator.test.ts`) and update README coverage badge.  

### Testing
- Ran linting with `npm run lint` which succeeded.  
- Ran the full test suite with `npm test` (Vitest) and all tests passed: `20` test files, `284` tests (all green).  
- Built the project with `npm run build` which succeeded and coverage/badge sync updated the README (coverage moved to 82%).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb36cc16d083339926deee8910e6cd)